### PR TITLE
Add @TestVisible annotations to RuleEngine

### DIFF
--- a/force-app/main/default/classes/util_closer_RuleEngine.cls
+++ b/force-app/main/default/classes/util_closer_RuleEngine.cls
@@ -122,6 +122,7 @@ public with sharing class util_closer_RuleEngine {
      * @param rule The rule to match against.
      * @return True if the case matches the rule.
      */
+    @TestVisible
     private static Boolean caseMatchesRule(Case c, util_closer_Case_Status_Rule__mdt rule) {
         // Check source status
         Set<String> sourceStatuses = parseStatusList(rule.Source_Status__c);
@@ -206,6 +207,7 @@ public with sharing class util_closer_RuleEngine {
      * @param listString The string to parse.
      * @return Set of trimmed values.
      */
+    @TestVisible
     private static Set<String> parseList(String listString) {
         Set<String> values = new Set<String>();
         if (String.isNotBlank(listString)) {
@@ -224,6 +226,7 @@ public with sharing class util_closer_RuleEngine {
      * @param dt The datetime to compare.
      * @return Number of days since the datetime.
      */
+    @TestVisible
     private static Integer getDaysSince(DateTime dt) {
         if (dt == null) {
             return 0;


### PR DESCRIPTION
## Summary
- Add `@TestVisible` annotations to RuleEngine private methods (`caseMatchesRule`, `parseList`, `getDaysSince`)
- Enables direct unit testing of these methods when needed in the future

## What was attempted
Extensive test additions were attempted to reach 90% coverage but were removed as they did not improve coverage due to Salesforce testing limitations:
- Cannot backdate `LastModifiedDate` (required by `Close_Stale_Waiting_Cases` rule)
- Cannot force platform exceptions to test catch blocks
- Cannot test empty rules path with deployed active metadata

## Test plan
- [x] All 139 existing tests pass
- [x] No functional changes to production code
- [x] Coverage unchanged (limitations are structural, not test gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)