### PR TITLE
Add days since created and record type filter to rule

### DIFF
--- a/force-app/main/default/customMetadata/util_closer_Case_Status_Rule.Never_Reached_an_Agent.md-meta.xml
+++ b/force-app/main/default/customMetadata/util_closer_Case_Status_Rule.Never_Reached_an_Agent.md-meta.xml
@@ -54,4 +54,12 @@
         <field>Stop_Processing__c</field>
         <value xsi:type="xsd:boolean">true</value>
     </values>
+    <values>
+        <field>Days_Since_Created__c</field>
+        <value xsi:type="xsd:double">7</value>
+    </values>
+    <values>
+        <field>Record_Type_Developer_Names__c</field>
+        <value xsi:type="xsd:string">PVL</value>
+    </values>
 </CustomMetadata>


### PR DESCRIPTION
## Summary
- Add 7-day threshold for Days_Since_Created__c
- Filter rule to only apply to Call Center (PVL) record type

## Test plan
- [x] Verify rule only matches cases created 7+ days ago
- [x] Verify rule only applies to Call Center record type

🤖 Generated with [Claude Code](https://claude.ai/code)