### PR TITLE
Add Origin, Owner Name Like, and Last Modified By filters to rules

### DIFF
--- a/force-app/main/default/classes/util_closer_CaseDataAccess.cls
+++ b/force-app/main/default/classes/util_closer_CaseDataAccess.cls
@@ -22,8 +22,10 @@ public without sharing class util_closer_CaseDataAccess {
         
         // Use SOQL with bind variables for proper query execution
         // Note: RecordTypeId is available but we query it separately if needed for rule evaluation
+        // Include Origin, Owner.Name, and LastModifiedBy.Name for rule filtering
         return Database.getQueryLocator([
-            SELECT Id, Status, LastModifiedDate, CreatedDate
+            SELECT Id, Status, LastModifiedDate, CreatedDate, Origin,
+                   Owner.Name, LastModifiedBy.Name
             FROM Case
             WHERE IsClosed = false
             AND Status IN :sourceStatuses

--- a/force-app/main/default/classes/util_closer_RuleEngine.cls
+++ b/force-app/main/default/classes/util_closer_RuleEngine.cls
@@ -42,7 +42,8 @@ public with sharing class util_closer_RuleEngine {
                    Description__c, Stop_Processing__c,
                    Child_Object_API_Name__c, Child_Lookup_Field__c,
                    Child_Filter_Field__c, Child_Filter_Value__c,
-                   Child_Filter_Operator__c, Require_Child_Record__c
+                   Child_Filter_Operator__c, Require_Child_Record__c,
+                   Origins__c, Owner_Name_Like__c, Last_Modified_By_Name_Like__c
             FROM util_closer_Case_Status_Rule__mdt
             WHERE Is_Active__c = true
             ORDER BY Execution_Order__c ASC
@@ -253,6 +254,44 @@ public with sharing class util_closer_RuleEngine {
             return false;
         }
 
+        // Check Origin filter
+        if (String.isNotBlank(rule.Origins__c)) {
+            Set<String> allowedOrigins = parseList(rule.Origins__c);
+            try {
+                String caseOrigin = (String)c.get('Origin');
+                if (caseOrigin == null || !allowedOrigins.contains(caseOrigin)) {
+                    return false;
+                }
+            } catch (SObjectException e) {
+                // Origin field not available, skip this check
+            }
+        }
+
+        // Check Owner Name Like filter
+        if (String.isNotBlank(rule.Owner_Name_Like__c)) {
+            try {
+                // Access Owner.Name using relationship path for polymorphic field
+                String ownerName = getRelatedFieldValue(c, 'Owner', 'Name');
+                if (ownerName == null || !matchesLikePattern(ownerName, rule.Owner_Name_Like__c)) {
+                    return false;
+                }
+            } catch (Exception e) {
+                // Owner not available, skip this check
+            }
+        }
+
+        // Check Last Modified By Name Like filter
+        if (String.isNotBlank(rule.Last_Modified_By_Name_Like__c)) {
+            try {
+                String lastModifiedByName = getRelatedFieldValue(c, 'LastModifiedBy', 'Name');
+                if (lastModifiedByName == null || !matchesLikePattern(lastModifiedByName, rule.Last_Modified_By_Name_Like__c)) {
+                    return false;
+                }
+            } catch (Exception e) {
+                // LastModifiedBy not available, skip this check
+            }
+        }
+
         return true;
     }
     
@@ -295,6 +334,65 @@ public with sharing class util_closer_RuleEngine {
             return 0;
         }
         return dt.date().daysBetween(Date.today());
+    }
+
+    /**
+     * @description Safely gets a field value from a related object.
+     * Handles cases where the relationship might not be queried.
+     * @param record The parent SObject.
+     * @param relationshipName The relationship name (e.g., 'Owner', 'LastModifiedBy').
+     * @param fieldName The field name on the related object (e.g., 'Name').
+     * @return The field value as String, or null if not available.
+     */
+    @TestVisible
+    private static String getRelatedFieldValue(SObject record, String relationshipName, String fieldName) {
+        if (record == null) {
+            return null;
+        }
+        try {
+            SObject relatedRecord = record.getSObject(relationshipName);
+            if (relatedRecord == null) {
+                return null;
+            }
+            return (String)relatedRecord.get(fieldName);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * @description Checks if a value matches a SQL LIKE pattern.
+     * Supports % as wildcard (matches any characters) and _ as single character wildcard.
+     * @param value The value to check.
+     * @param likePattern The LIKE pattern to match against.
+     * @return True if the value matches the pattern.
+     */
+    @TestVisible
+    private static Boolean matchesLikePattern(String value, String likePattern) {
+        if (value == null || likePattern == null) {
+            return false;
+        }
+
+        // Convert SQL LIKE pattern to regex
+        // Escape regex special characters except % and _
+        String regex = '';
+        for (Integer i = 0; i < likePattern.length(); i++) {
+            String ch = likePattern.substring(i, i + 1);
+            if (ch == '%') {
+                regex += '.*';
+            } else if (ch == '_') {
+                regex += '.';
+            } else if ('\\[](){}^$.|*+?'.contains(ch)) {
+                regex += '\\' + ch;
+            } else {
+                regex += ch;
+            }
+        }
+
+        // Case-insensitive match
+        Pattern regexPattern = Pattern.compile('(?i)^' + regex + '$');
+        Matcher m = regexPattern.matcher(value);
+        return m.matches();
     }
 }
 

--- a/force-app/main/default/classes/util_closer_RuleEngine_Test.cls
+++ b/force-app/main/default/classes/util_closer_RuleEngine_Test.cls
@@ -1551,5 +1551,544 @@ private class util_closer_RuleEngine_Test {
 
         resetMockRules();
     }
+
+    // ==================== Origin Filter Tests ====================
+
+    @isTest
+    static void testEvaluateCases_WithOriginFilter_Match() {
+        // Test Origin filter matches
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin FROM Case WHERE Id = :testCase.Id];
+
+        // Create rule with Origin filter
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Origin_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Origins__c = 'Web;Phone'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match because Origin is in the list
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_WithOriginFilter_NoMatch() {
+        // Test Origin filter does not match
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Email');
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin FROM Case WHERE Id = :testCase.Id];
+
+        // Create rule with Origin filter that doesn't include Email
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Origin_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Origins__c = 'Web;Phone'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should NOT match because Origin is not in the list
+        System.assertEquals(0, changes.size(), 'Should have 0 changes');
+
+        resetMockRules();
+    }
+
+    // ==================== Owner Name Like Filter Tests ====================
+
+    @isTest
+    static void testEvaluateCases_WithOwnerNameLike_Match() {
+        // Test Owner Name Like filter matches using wildcard
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web', OwnerId = UserInfo.getUserId());
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, OwnerId, Owner.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Skip if owner name is not accessible (e.g., assignment rules or permissions)
+        String ownerName = testCase.Owner != null ? testCase.Owner.Name : null;
+        if (String.isBlank(ownerName)) {
+            System.assert(true, 'Skipping - owner name not accessible');
+            return;
+        }
+
+        // Create rule with Owner Name Like filter - use wildcard to match any name
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Owner_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Owner_Name_Like__c = '%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match because wildcard matches any name
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_WithOwnerNameLike_NoMatch() {
+        // Test Owner Name Like filter does not match
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, Owner.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Create rule with Owner Name Like filter that won't match
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Owner_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Owner_Name_Like__c = '%NonExistentName%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should NOT match
+        System.assertEquals(0, changes.size(), 'Should have 0 changes');
+
+        resetMockRules();
+    }
+
+    // ==================== Last Modified By Name Like Filter Tests ====================
+
+    @isTest
+    static void testEvaluateCases_WithLastModifiedByNameLike_Match() {
+        // Test Last Modified By Name Like filter matches
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, LastModifiedBy.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Create rule with Last Modified By Name Like filter - match any (wildcard)
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'LastModBy_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Last_Modified_By_Name_Like__c = '%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match because wildcard matches any name
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_WithLastModifiedByNameLike_NoMatch() {
+        // Test Last Modified By Name Like filter does not match
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, LastModifiedBy.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Create rule with Last Modified By Name Like filter that won't match
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'LastModBy_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Last_Modified_By_Name_Like__c = '%NonExistentName%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should NOT match
+        System.assertEquals(0, changes.size(), 'Should have 0 changes');
+
+        resetMockRules();
+    }
+
+    // ==================== matchesLikePattern Tests ====================
+
+    @isTest
+    static void testMatchesLikePattern_StartsWith() {
+        // Test LIKE pattern with trailing wildcard - directly test the helper method
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        // Test the matchesLikePattern method directly via case evaluation
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web', OwnerId = UserInfo.getUserId());
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, Owner.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Get the actual owner name from the case and build a pattern
+        String actualOwnerName = testCase.Owner != null ? testCase.Owner.Name : null;
+
+        // Skip test if owner name is not available (e.g., Queue owner)
+        if (String.isBlank(actualOwnerName)) {
+            System.assert(true, 'Skipping - owner name not available');
+            return;
+        }
+
+        // Build pattern from first char of actual owner name
+        String startPattern = actualOwnerName.substring(0, 1) + '%';
+
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'StartsWith_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Owner_Name_Like__c = startPattern
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match since pattern is built from actual name
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testMatchesLikePattern_Contains() {
+        // Test LIKE pattern with wildcards on both sides
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web', OwnerId = UserInfo.getUserId());
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, Owner.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Get the actual owner name from the case
+        String actualOwnerName = testCase.Owner != null ? testCase.Owner.Name : null;
+
+        // Skip test if owner name is not available
+        if (String.isBlank(actualOwnerName)) {
+            System.assert(true, 'Skipping - owner name not available');
+            return;
+        }
+
+        // Use first character with contains pattern
+        String containsPattern = '%' + actualOwnerName.substring(0, 1) + '%';
+
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Contains_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Owner_Name_Like__c = containsPattern
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testMatchesLikePattern_SingleCharWildcard() {
+        // Test LIKE pattern with single char wildcard (_)
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web', OwnerId = UserInfo.getUserId());
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, Owner.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Get the actual owner name from the case
+        String actualOwnerName = testCase.Owner != null ? testCase.Owner.Name : null;
+
+        // Skip test if owner name is not available or too short
+        if (String.isBlank(actualOwnerName) || actualOwnerName.length() < 2) {
+            System.assert(true, 'Skipping - owner name not available or too short');
+            return;
+        }
+
+        // Pattern: first char + single char wildcard + rest matches anything
+        String singleCharPattern = actualOwnerName.substring(0, 1) + '_%';
+
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'SingleChar_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Owner_Name_Like__c = singleCharPattern
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_CombinedFilters() {
+        // Test combining Origin, Owner Name Like, and Last Modified By Name Like filters
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web', OwnerId = UserInfo.getUserId());
+        insert testCase;
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate, Origin, OwnerId, Owner.Name, LastModifiedBy.Name FROM Case WHERE Id = :testCase.Id];
+
+        // Skip if owner name is not accessible
+        String ownerName = testCase.Owner != null ? testCase.Owner.Name : null;
+        if (String.isBlank(ownerName)) {
+            System.assert(true, 'Skipping - owner name not accessible');
+            return;
+        }
+
+        // Create rule with all three filters - use wildcards for name fields
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Combined_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Origins__c = 'Web;Phone',
+            Owner_Name_Like__c = '%',
+            Last_Modified_By_Name_Like__c = '%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should match all filters
+        System.assertEquals(1, changes.size(), 'Should have 1 change');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_OriginNotQueried() {
+        // Test when Origin field is not queried
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        // Deliberately don't query Origin
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate FROM Case WHERE Id = :testCase.Id];
+
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Origin_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Origins__c = 'Web'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute - should handle gracefully
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should handle missing field gracefully
+        System.assertNotEquals(null, changes, 'Changes should not be null');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_OwnerNotQueried() {
+        // Test when Owner relationship is not queried
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        // Deliberately don't query Owner.Name
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate FROM Case WHERE Id = :testCase.Id];
+
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'Owner_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Owner_Name_Like__c = '%Test%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute - should handle gracefully
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should handle missing field gracefully
+        System.assertNotEquals(null, changes, 'Changes should not be null');
+
+        resetMockRules();
+    }
+
+    @isTest
+    static void testEvaluateCases_LastModifiedByNotQueried() {
+        // Test when LastModifiedBy relationship is not queried
+        util_closer_SettingsService.mockSettings = util_closer_TestDataFactory.createSettings(200, true, true);
+
+        Case testCase = new Case(Subject = 'Test Case', Status = 'New', Origin = 'Web');
+        insert testCase;
+        // Deliberately don't query LastModifiedBy.Name
+        testCase = [SELECT Id, Status, LastModifiedDate, CreatedDate FROM Case WHERE Id = :testCase.Id];
+
+        util_closer_Case_Status_Rule__mdt rule = new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = 'LastModBy_Rule',
+            Is_Active__c = true,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Execution_Order__c = 1,
+            Last_Modified_By_Name_Like__c = '%Test%'
+        );
+
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{ rule };
+        List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+
+        // Execute - should handle gracefully
+        Test.startTest();
+        Map<Id, util_closer_RuleEngine.CaseChange> changes = util_closer_RuleEngine.evaluateCases(
+            new List<Case>{ testCase },
+            rules,
+            null
+        );
+        Test.stopTest();
+
+        // Verify - should handle missing field gracefully
+        System.assertNotEquals(null, changes, 'Changes should not be null');
+
+        resetMockRules();
+    }
 }
 

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Last_Modified_By_Name_Like__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Last_Modified_By_Name_Like__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Modified_By_Name_Like__c</fullName>
+    <description>Pattern to match against Last Modified By Name using LIKE operator. Supports % as wildcard. Example: %Google% matches names containing Google.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Enter a pattern to match the Last Modified By Name. Use % as wildcard. Example: %Google% matches any name containing Google.</inlineHelpText>
+    <label>Last Modified By Name Like</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Origins__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Origins__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Origins__c</fullName>
+    <description>Semicolon-separated list of Case Origins to match. Leave blank to match all origins. Example: IVR Call;Web;Email</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Enter one or more Case Origin values separated by semicolons. The rule will only match Cases with one of these origins. Leave blank to match all origins.</inlineHelpText>
+    <label>Origins</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Owner_Name_Like__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Owner_Name_Like__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Owner_Name_Like__c</fullName>
+    <description>Pattern to match against Owner Name using LIKE operator. Supports % as wildcard. Example: Google% matches names starting with Google.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Enter a pattern to match the Case Owner Name. Use % as wildcard. Example: %Google% matches any owner name containing Google.</inlineHelpText>
+    <label>Owner Name Like</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- Add **Origins__c** field to filter cases by Origin (supports semicolon-separated multiple values)
- Add **Owner_Name_Like__c** field with SQL LIKE pattern matching for Owner Name (supports % and _ wildcards)
- Add **Last_Modified_By_Name_Like__c** field with LIKE pattern matching for Last Modified By Name
- Update RuleEngine to evaluate new filters
- Update CaseDataAccess query to include Origin, Owner.Name, and LastModifiedBy.Name

## Test plan
- [x] Unit tests pass (143 tests, 100% pass rate)
- [ ] Deploy to dcca-migration and verify custom metadata rule works
- [ ] Run batch job and verify cases with matching Origin/Owner/LastModifiedBy are processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)