### PR TITLE
Replace CSV export with Copy SOQL to Clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ $RECYCLE.BIN/
 **/venv/
 docs/analysis/
 
-# Custom Metadata (managed per-org, not in source control)
+# Custom Metadata (managed per-org, not in source control by default)
 force-app/main/default/customMetadata/
+!force-app/main/default/customMetadata/util_closer_Case_Status_Rule__mdt.Abandoned_Calls.md-meta.xml

--- a/docs/closinator-child-object-debug/child-object-config-fixes.md
+++ b/docs/closinator-child-object-debug/child-object-config-fixes.md
@@ -1,0 +1,154 @@
+# Child Object Configuration Bug Fixes
+
+**Branch:** `closinator-child-object-debug`
+**Date:** March 23, 2026
+
+Three misconfigured fields on a `util_closer_Case_Status_Rule__mdt` custom metadata record that prevent the child-record filter and owner-name filter from working correctly. The plan below covers the immediate data fixes and accompanying field-level help text improvements to prevent recurrence.
+
+---
+
+## Changes Implemented
+
+### Metadata Record: `Abandoned_Calls`
+
+| Field | Prior Value | Current Value |
+| --- | --- | --- |
+| `Child_Filter_Field__c` | `UJET__UJET_Session__c.UJET__Fail_Reason__c` | `UJET__Fail_Reason__c` |
+| `Child_Filter_Value__c` | `'eu_abandoned'` | `eu_abandoned` |
+| `Owner_Name_Like__c` | `%Google%` | `%Google%` (confirmed valid — production user) |
+
+Record source file added to source control: [`customMetadata/util_closer_Case_Status_Rule__mdt.Abandoned_Calls.md-meta.xml`](../../force-app/main/default/customMetadata/util_closer_Case_Status_Rule__mdt.Abandoned_Calls.md-meta.xml)
+
+### Field Help Text
+
+| Field | Prior `inlineHelpText` | Current `inlineHelpText` |
+| --- | --- | --- |
+| `Child_Filter_Field__c` | `Enter the API name of the field on the child object to check against the filter value.` | `Field API name only. Do not use dot notation. (Example: UJET__Status__c).` |
+| `Child_Filter_Value__c` | `Enter value(s) to match. Separate multiple values with semicolons.` | `Raw values only. Do not wrap in quotes. Separate multiple values with semicolons. (Example: Finished;Completed).` |
+| `Owner_Name_Like__c` | `Enter a pattern to match the Case Owner Name. Use % as wildcard. Example: %Google% matches any owner name containing Google.` | `Leave blank to match all owners. Use % as wildcard. (Example: %Google%).` |
+| `Last_Modified_By_Name_Like__c` | `Enter a pattern to match the Last Modified By Name. Use % as wildcard. Example: %Google% matches any name containing Google.` | `Leave blank to match all. Use % as wildcard. (Example: %Google%).` |
+
+Both changes deployed to `dcca-devcc` on March 23, 2026.
+
+---
+
+## Summary of Errors
+
+| Field | Current Value | Correct Value | Issue |
+| --- | --- | --- | --- |
+| `Child_Filter_Field__c` | `UJET__UJET_Session__c.UJET__Fail_Reason__c` | `UJET__Fail_Reason__c` | Object name prefix causes the field to fail schema validation and be silently dropped from the query. Evaluation then fails trying to read a field that was never fetched. |
+| `Child_Filter_Value__c` | `'eu_abandoned'` | `eu_abandoned` | Literal single quotes are included in the stored value. The code does a case-sensitive exact match — `'eu_abandoned'` (with quotes) will never equal `eu_abandoned` (without quotes). |
+| `Owner_Name_Like__c` | `%Google%` | Remove or correct | This restricts the rule to only cases owned by users with "Google" in their name. This appears to be a leftover test value and would exclude virtually all real cases in production. |
+
+---
+
+## Part 1: Metadata Record Fixes
+
+The custom metadata records are not stored in source control in this repository (no `customMetadata/` directory). The fixes must be applied in one of two ways:
+
+1. **Setup UI:** Navigate to Setup → Custom Metadata Types → Case Status Rule → find the record → edit the three fields.
+2. **Metadata API deployment:** Create a `customMetadata/` record file and deploy it via `sf project deploy start`.
+
+Option 1 is recommended for a quick targeted fix; option 2 if you want the corrected values tracked in source control going forward.
+
+---
+
+### Error 1: `Child_Filter_Field__c` — Object-qualified field name fails schema validation
+
+**Current value:** `UJET__UJET_Session__c.UJET__Fail_Reason__c`
+**Correct value:** `UJET__Fail_Reason__c`
+
+#### Why it breaks
+
+`util_closer_CaseDataAccess.cls` validates the field name against the child object's schema describe map. The map keys are bare field API names (e.g. `ujet__fail_reason__c`). The dot-notation value `ujet__ujet_session__c.ujet__fail_reason__c` is not a valid key, so the field **silently fails validation and is dropped from the SELECT list**. The SOQL query executes successfully but never fetches the filter field.
+
+Later, `util_closer_ChildRecordService.cls` attempts to read the field value from the returned record using `child.get(criteria.childFilterField)`. Because the field was never SELECTed, this throws an `SObjectException`. The catch block returns `false`, and **every child record is treated as non-matching** — the rule silently produces wrong results.
+
+#### Fix
+
+Change the value from `UJET__UJET_Session__c.UJET__Fail_Reason__c` to `UJET__Fail_Reason__c`. The child object is already specified separately in `Child_Object_API_Name__c`, so only the bare field API name belongs here.
+
+---
+
+### Error 2: `Child_Filter_Value__c` — Embedded literal quotes prevent matching
+
+**Current value:** `'eu_abandoned'` (with single quotes)
+**Correct value:** `eu_abandoned` (no quotes)
+
+#### Why it breaks
+
+The `parseValues` method in `util_closer_ChildRecordService.cls` splits the stored string on semicolons and trims whitespace only — there is no quote-stripping logic. This produces a Set containing the literal string `'eu_abandoned'` (7 characters, with quotes).
+
+At match time, the `Equals` operator does an exact `Set.contains()` check against `String.valueOf(fieldValue)`. The actual field value on the child record is `eu_abandoned` (no quotes). Since `'eu_abandoned' != eu_abandoned`, the comparison **always returns false** and no child records are ever matched.
+
+#### Fix
+
+Change the value from `'eu_abandoned'` to `eu_abandoned`. No quotes, no special delimiters — just the raw picklist/text value exactly as it appears on the record.
+
+---
+
+### Error 3: `Owner_Name_Like__c` — Test data leftover excludes all production cases
+
+**Current value:** `%Google%`
+**Correct value:** Blank (removed), or replaced with a real production pattern
+
+#### Why it breaks
+
+`util_closer_RuleEngine.cls` evaluates this field against each case's `Owner.Name` using a regex-based LIKE pattern match. The pattern `%Google%` translates to `(?i)^.*Google.*$`, meaning the owner's name must contain "Google". In production, virtually no case owners will have "Google" in their name, so **every case is excluded from this rule**.
+
+When the field is blank, the `String.isNotBlank()` guard skips the check entirely, allowing all cases through regardless of owner.
+
+#### Fix
+
+Clear the `Owner_Name_Like__c` field (set it to blank/null). If there is a legitimate owner restriction needed, replace `%Google%` with the correct production pattern.
+
+---
+
+## Part 2: Field Help Text Improvements
+
+All three errors share the same root cause: the field-level `description` and `inlineHelpText` on the custom metadata type don't give users enough information to avoid common mistakes. The `inlineHelpText` value is what appears on the record editing screen in Salesforce Setup, making it the most effective place to guide users at the moment they are entering values.
+
+Files to edit:
+
+- [`Child_Filter_Field__c.field-meta.xml`](../../force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Child_Filter_Field__c.field-meta.xml)
+- [`Child_Filter_Value__c.field-meta.xml`](../../force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Child_Filter_Value__c.field-meta.xml)
+- [`Owner_Name_Like__c.field-meta.xml`](../../force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Owner_Name_Like__c.field-meta.xml)
+- [`Last_Modified_By_Name_Like__c.field-meta.xml`](../../force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Last_Modified_By_Name_Like__c.field-meta.xml)
+
+---
+
+### `Child_Filter_Field__c`
+
+| | Current | Proposed |
+| --- | --- | --- |
+| `description` | `API name of the field on the child object to evaluate (e.g., UJET__Status__c).` | `API name of the field on the child object to evaluate. Enter the field name only, without the object prefix. Correct: UJET__Fail_Reason__c. Incorrect: UJET__UJET_Session__c.UJET__Fail_Reason__c.` |
+| `inlineHelpText` | `Enter the API name of the field on the child object to check against the filter value.` | `Field API name only. Do not use dot notation. (Example: UJET__Status__c).` |
+
+---
+
+### `Child_Filter_Value__c`
+
+| | Current | Proposed |
+| --- | --- | --- |
+| `description` | `Value(s) to match on the child filter field. Use semicolon to separate multiple values (e.g., Finished;Completed).` | `Raw value(s) to match on the child filter field. Do not wrap in quotes. Use semicolons to separate multiple values. Example: eu_abandoned or Finished;Completed.` |
+| `inlineHelpText` | `Enter value(s) to match. Separate multiple values with semicolons.` | `Raw values only. Do not wrap in quotes. Separate multiple values with semicolons. (Example: Finished;Completed).` |
+
+---
+
+### `Owner_Name_Like__c`
+
+| | Current | Proposed |
+| --- | --- | --- |
+| `description` | `Pattern to match against Owner Name using LIKE operator. Supports % as wildcard. Example: Google% matches names starting with Google.` | `Optional LIKE pattern to restrict this rule by Case Owner Name. Leave blank to apply to all owners. Use % as multi-character wildcard and _ as single-character wildcard.` |
+| `inlineHelpText` | `Enter a pattern to match the Case Owner Name. Use % as wildcard. Example: %Google% matches any owner name containing Google.` | `Leave blank to match all owners. Use % as wildcard. (Example: %Google%).` |
+
+---
+
+### `Last_Modified_By_Name_Like__c` (related fix)
+
+This field has the same help text pattern as `Owner_Name_Like__c` and should be updated for consistency.
+
+| | Current | Proposed |
+| --- | --- | --- |
+| `description` | `Pattern to match against Last Modified By Name using LIKE operator. Supports % as wildcard. Example: %Google% matches names containing Google.` | `Optional LIKE pattern to restrict this rule by Last Modified By Name. Leave blank to apply to all. Use % as multi-character wildcard and _ as single-character wildcard.` |
+| `inlineHelpText` | `Enter a pattern to match the Last Modified By Name. Use % as wildcard. Example: %Google% matches any name containing Google.` | `Leave blank to match all. Use % as wildcard. (Example: %Google%).` |

--- a/docs/closinator-rule-viewer/rule-viewer-feature.md
+++ b/docs/closinator-rule-viewer/rule-viewer-feature.md
@@ -1,0 +1,212 @@
+# Read-Only Rules Display on Closinator Dashboard
+
+**Branch:** `closinator-rule-viewer`
+**Date:** March 30, 2026
+
+Users need to see which rules and criteria are active on the Closinator dashboard without navigating to Setup or Custom Metadata. This feature adds a new read-only LWC component that displays all active `util_closer_Case_Status_Rule__mdt` records in a collapsible, accordion-based layout between the Scheduler Manager and Log Viewer.
+
+---
+
+## Architecture
+
+The Closinator dashboard is a flexipage that composes independent LWC components. Each component has its own Apex controller following a one-to-one pattern:
+
+| Component | Controller | Responsibility |
+| --- | --- | --- |
+| `util_closer_schedulerManager` | `util_closer_SchedulerController` | Job scheduling, cron, settings |
+| **`util_closer_RuleViewer` (NEW)** | **`util_closer_RuleViewerController` (NEW)** | **Read-only rule display** |
+| `util_closer_LogViewer` | `util_closer_LogViewerController` | Batch/case log browsing |
+
+The new controller wraps the existing `util_closer_RuleEngine.getActiveRules()` method, which already queries all active rules ordered by `Execution_Order__c`. No new SOQL or data access layer is needed.
+
+---
+
+## Files Created
+
+### Apex
+
+- [`util_closer_RuleViewerController.cls`](../../force-app/main/default/classes/util_closer_RuleViewerController.cls) -- single `@AuraEnabled(cacheable=true)` method returning `List<Map<String, Object>>`
+- [`util_closer_RuleViewerController.cls-meta.xml`](../../force-app/main/default/classes/util_closer_RuleViewerController.cls-meta.xml)
+- [`util_closer_RuleViewerController_Test.cls`](../../force-app/main/default/classes/util_closer_RuleViewerController_Test.cls) -- 5 test methods, 100% line coverage
+- [`util_closer_RuleViewerController_Test.cls-meta.xml`](../../force-app/main/default/classes/util_closer_RuleViewerController_Test.cls-meta.xml)
+
+### LWC
+
+- [`util_closer_RuleViewer.html`](../../force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.html)
+- [`util_closer_RuleViewer.js`](../../force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js)
+- [`util_closer_RuleViewer.css`](../../force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.css)
+- [`util_closer_RuleViewer.js-meta.xml`](../../force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js-meta.xml)
+
+## Files Modified
+
+- [`util_closer_Dashboard.flexipage-meta.xml`](../../force-app/main/default/flexipages/util_closer_Dashboard.flexipage-meta.xml) -- insert `util_closer_RuleViewer` between the scheduler and log viewer
+
+---
+
+## Apex Controller Design
+
+`util_closer_RuleViewerController.getActiveRules()` calls `util_closer_RuleEngine.getActiveRules()` and maps each `util_closer_Case_Status_Rule__mdt` record into a flat `Map<String, Object>` with camelCase keys. This avoids serialization issues with null custom metadata fields and gives the LWC clean, predictable JSON.
+
+### Field Mapping
+
+| MDT Field | Map Key | Criteria Group |
+| --- | --- | --- |
+| `DeveloperName` | `developerName` | Core |
+| `MasterLabel` | `label` | Core |
+| `Execution_Order__c` | `executionOrder` | Core |
+| `Source_Status__c` | `sourceStatus` | Core |
+| `Target_Status__c` | `targetStatus` | Core |
+| `Target_Reason__c` | `targetReason` | Core |
+| `Description__c` | `description` | Core |
+| `Stop_Processing__c` | `stopProcessing` | Core |
+| `Days_Since_Last_Modified__c` | `daysSinceLastModified` | Timing |
+| `Days_Since_Created__c` | `daysSinceCreated` | Timing |
+| `Days_Since_Last_Activity__c` | `daysSinceLastActivity` | Timing |
+| `Record_Type_Developer_Names__c` | `recordTypeDeveloperNames` | Filtering |
+| `Exclude_Record_Type_Developer_Names__c` | `excludeRecordTypeDeveloperNames` | Filtering |
+| `Origins__c` | `origins` | Filtering |
+| `Owner_Name_Like__c` | `ownerNameLike` | Filtering |
+| `Last_Modified_By_Name_Like__c` | `lastModifiedByNameLike` | Filtering |
+| `Additional_Filter_Logic__c` | `additionalFilterLogic` | Filtering |
+| `Child_Object_API_Name__c` | `childObjectApiName` | Child Object |
+| `Child_Lookup_Field__c` | `childLookupField` | Child Object |
+| `Child_Filter_Field__c` | `childFilterField` | Child Object |
+| `Child_Filter_Value__c` | `childFilterValue` | Child Object |
+| `Child_Filter_Operator__c` | `childFilterOperator` | Child Object |
+| `Require_Child_Record__c` | `requireChildRecord` | Child Object |
+
+### Error Handling
+
+Follows the same pattern as `util_closer_SchedulerController`: catch blocks wrap exceptions in `AuraHandledException` with `setMessage()` so the LWC receives a readable error string. A `@TestVisible` static boolean `throwExceptionOnGetRules` enables deterministic exception testing.
+
+---
+
+## LWC UI Design
+
+### Collapsed State (Default)
+
+The component renders a `lightning-card` with a compact header showing the title, a count badge (e.g., "3"), and a chevron toggle button. When collapsed, the card body is hidden. This takes up a single line on the dashboard -- zero crowding.
+
+### Expanded State
+
+When expanded, the card body contains a `lightning-accordion` with one section per active rule. Each section uses progressive disclosure:
+
+**Section header (always visible):**
+
+> #1 -- Rule Label | Source Status -> Target Status | 30d since modified
+
+**Section body (on click):** A read-only detail grid grouped into four categories. Only populated fields are displayed -- blank/null criteria are hidden via `template if:true` guards.
+
+- **Core:** Source Status, Target Status, Target Reason, Execution Order, Description, Stop Processing
+- **Timing:** Days Since Last Modified, Days Since Created, Days Since Last Activity
+- **Filtering:** Record Types (include/exclude), Origins, Owner Name Like, Last Modified By Name Like, Additional Filter Logic
+- **Child Object:** Child Object API Name, Lookup Field, Filter Field, Filter Value, Filter Operator, Require Child Record
+
+### Styling
+
+CSS uses SLDS design tokens matching `util_closer_schedulerManager`:
+
+| Element | Pattern Source | Token |
+| --- | --- | --- |
+| Section background | `.settings-section` | `var(--slds-g-color-neutral-base-100, #ffffff)` |
+| Section border | `.config-section` | `1px solid var(--slds-g-color-border-base-1, #e5e5e5)` |
+| Border radius | `.config-section` | `0.5rem` |
+| Field labels | `.setting-label` | `font-weight: 600; color: var(--slds-g-color-neutral-base-30)` |
+| Field values | `.setting-value` | `color: var(--slds-g-color-neutral-base-10)` |
+| Count badge | `.success` badge | green variant with white text |
+
+### JS Patterns
+
+| Pattern | Source | Implementation |
+| --- | --- | --- |
+| Data loading | Scheduler `@wire(getJobStatus)` | `@wire(getActiveRules)` with `wiredRulesResult` for `refreshApex` |
+| Error handling | Scheduler `handleError()` | Same `error.body.message` extraction + `ShowToastEvent` |
+| Refresh | Scheduler `handleRefresh()` | `refreshApex(this.wiredRulesResult)` + success toast |
+| State | Scheduler `@track` properties | `@track isExpanded`, `@track rules`, `@track isLoading`, `@track error` |
+
+---
+
+## Test Coverage
+
+| Test Method | Lines Covered | Purpose |
+| --- | --- | --- |
+| `testGetActiveRules_ReturnsMappedData` | All map puts + return | Happy path with 2 mock rules |
+| `testGetActiveRules_EmptyRules` | getActiveRules + empty loop + return | Zero rules returns empty list |
+| `testGetActiveRules_ForcedException` | Exception flag + catch + throw | AuraHandledException with correct message |
+| `testGetActiveRules_NullFields` | All map puts with nulls | Optional fields don't crash |
+| `testGetActiveRules_VerifyFieldMapping` | All map puts | Every MDT field maps to correct key |
+
+Coverage target: **100% lines, 100% methods, all 5 tests passing.**
+
+Tests use `util_closer_RuleEngine.mockRules` for dependency injection, the same proven pattern from `util_closer_RuleEngine_Test.cls`. No test data factory changes or DML required.
+
+---
+
+## Flexipage Layout
+
+The dashboard flexipage stacks three components vertically in the main region:
+
+```
++----------------------------------------------+
+|  util_closer_schedulerManager                |
+|  (Scheduler, cron, settings)                 |
++----------------------------------------------+
+|  util_closer_RuleViewer (NEW)                |
+|  (Collapsed: "Active Rules [3]" + chevron)   |
++----------------------------------------------+
+|  util_closer_LogViewer                       |
+|  (Batch logs, case logs, filters)            |
++----------------------------------------------+
+```
+
+The rule viewer sits between the scheduler (configuration) and log viewer (execution results), creating a natural top-to-bottom flow: configure -> view rules -> view results.
+
+---
+
+## Deployment Manifest
+
+Components to promote when moving this feature to a higher environment.
+
+### Deployment Order
+
+Deploy in the order listed below. The LWC depends on the Apex controller, and the FlexiPage depends on the LWC.
+
+### 1. Apex Classes (New)
+
+| Type | Component Name | File Path |
+| --- | --- | --- |
+| ApexClass | `util_closer_RuleViewerController` | `force-app/main/default/classes/util_closer_RuleViewerController.cls` |
+| ApexClass | `util_closer_RuleViewerController` | `force-app/main/default/classes/util_closer_RuleViewerController.cls-meta.xml` |
+| ApexClass | `util_closer_RuleViewerController_Test` | `force-app/main/default/classes/util_closer_RuleViewerController_Test.cls` |
+| ApexClass | `util_closer_RuleViewerController_Test` | `force-app/main/default/classes/util_closer_RuleViewerController_Test.cls-meta.xml` |
+
+### 2. Lightning Web Component (New)
+
+| Type | Component Name | File Path |
+| --- | --- | --- |
+| LightningComponentBundle | `util_closer_RuleViewer` | `force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.html` |
+| LightningComponentBundle | `util_closer_RuleViewer` | `force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js` |
+| LightningComponentBundle | `util_closer_RuleViewer` | `force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.css` |
+| LightningComponentBundle | `util_closer_RuleViewer` | `force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js-meta.xml` |
+
+### 3. FlexiPage (Modified)
+
+| Type | Component Name | File Path |
+| --- | --- | --- |
+| FlexiPage | `util_closer_Dashboard` | `force-app/main/default/flexipages/util_closer_Dashboard.flexipage-meta.xml` |
+
+### Summary
+
+| | New | Modified | Total |
+| --- | --- | --- | --- |
+| Apex Classes | 4 files (2 classes) | 0 | 4 |
+| LWC Bundle | 4 files (1 component) | 0 | 4 |
+| FlexiPage | 0 | 1 file | 1 |
+| **Total** | **8** | **1** | **9** |
+
+### Not Included
+
+- No custom objects, fields, or metadata types changed
+- No permission sets updated
+- No existing Apex classes modified
+- No existing LWC components modified

--- a/docs/closinator-soql-toast/soql-toast-feature.md
+++ b/docs/closinator-soql-toast/soql-toast-feature.md
@@ -1,0 +1,37 @@
+# Copy SOQL to Clipboard (replaces CSV Export)
+
+## Summary
+
+The Log Viewer's export button now copies a SOQL query to the clipboard instead of downloading a CSV file. The user can paste this query into Developer Console, Workbench, Data Loader, or any other SOQL-capable tool to retrieve the case log data.
+
+## Why the CSV export was removed
+
+The original `exportCaseLogsAsCsv` Apex method queried up to 50,000 `util_closer_Case_Log__c` records and built a CSV string in a single synchronous `@AuraEnabled` call. Salesforce enforces a **6 MB heap size limit** on synchronous Apex. With verbose logging enabled, a single batch run can produce thousands of case log records (one per evaluated case), and the in-memory cost of holding the query results, the CSV row list, and the final joined string simultaneously exceeded the heap limit at roughly 6,000-8,000 records.
+
+The LWC download mechanism (`document.createElement('a')` with a Blob URL) also had compatibility issues in Lightning Web Security contexts.
+
+## How the new button works
+
+1. The user clicks the clipboard icon button in the Case Logs panel header.
+2. The LWC calls `getCaseLogExportQuery` -- an Apex method that builds the SOQL string using the same filter logic as the UI (batch log ID, processing result, matched rule, search term) but **does not execute** the query.
+3. The SOQL string is copied to the clipboard via `navigator.clipboard.writeText()`.
+4. A sticky success toast displays the full SOQL query so the user can verify what was copied.
+
+## Where to run the SOQL
+
+Paste the copied query into any of these tools:
+
+- **Developer Console** -- Setup > Developer Console > Query Editor tab
+- **Workbench** -- workbench.developerforce.com > SOQL Query
+- **Data Loader** -- Export wizard with custom SOQL
+- **VS Code SOQL Extension** -- Salesforce Extensions for VS Code
+- **Anonymous Apex** -- `Database.query(soqlString)` in Execute Anonymous
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `force-app/main/default/classes/util_closer_LogViewerController.cls` | Replaced `exportCaseLogsAsCsv` with `getCaseLogExportQuery`; removed `escapeCsvValue` helper |
+| `force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.js` | Replaced CSV download handler with clipboard copy + sticky toast |
+| `force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.html` | Changed button icon to `utility:copy_to_clipboard`, updated tooltip |
+| `force-app/main/default/classes/util_closer_LogViewerController_Test.cls` | Replaced CSV export tests with SOQL query string tests |

--- a/force-app/main/default/classes/util_closer_LogViewerController.cls
+++ b/force-app/main/default/classes/util_closer_LogViewerController.cls
@@ -208,13 +208,14 @@ public with sharing class util_closer_LogViewerController {
     }
     
     /**
-     * @description Export case logs for a batch as CSV data
+     * @description Build the SOQL query for case logs matching the given filters.
+     * Returns the query string for the user to run externally (Dev Console, Workbench, etc.).
      * @param batchLogId The batch log ID
      * @param filterJson Filter criteria
-     * @return CSV string of case log data
+     * @return SOQL query string
      */
     @AuraEnabled
-    public static String exportCaseLogsAsCsv(Id batchLogId, String filterJson) {
+    public static String getCaseLogExportQuery(Id batchLogId, String filterJson) {
         CaseLogFilter filter = parseCaseLogFilter(filterJson);
         if (filter == null) {
             filter = new CaseLogFilter();
@@ -222,36 +223,10 @@ public with sharing class util_closer_LogViewerController {
         filter.batchLogId = batchLogId;
         
         String whereClause = buildCaseWhereClause(filter);
-        String query = 'SELECT Name, Case_Number__c, Original_Status__c, Target_Status__c, ' +
-                      'Processing_Result__c, Matched_Rule_Label__c, Error_Message__c, CreatedDate ' +
-                      'FROM util_closer_Case_Log__c WHERE ' + whereClause +
-                      ' ORDER BY CreatedDate DESC LIMIT 50000';
-        
-        List<util_closer_Case_Log__c> logs = Database.query(query);
-        
-        // Build CSV
-        List<String> headers = new List<String>{
-            'Log Name', 'Case Number', 'Original Status', 'Target Status',
-            'Result', 'Matched Rule', 'Error Message', 'Created Date'
-        };
-        
-        List<String> rows = new List<String>{ String.join(headers, ',') };
-        
-        for (util_closer_Case_Log__c log : logs) {
-            List<String> values = new List<String>{
-                escapeCsvValue(log.Name),
-                escapeCsvValue(log.Case_Number__c),
-                escapeCsvValue(log.Original_Status__c),
-                escapeCsvValue(log.Target_Status__c),
-                escapeCsvValue(log.Processing_Result__c),
-                escapeCsvValue(log.Matched_Rule_Label__c),
-                escapeCsvValue(log.Error_Message__c),
-                log.CreatedDate != null ? log.CreatedDate.format() : ''
-            };
-            rows.add(String.join(values, ','));
-        }
-        
-        return String.join(rows, '\n');
+        return 'SELECT Name, Case_Number__c, Original_Status__c, Target_Status__c, ' +
+               'Processing_Result__c, Matched_Rule_Label__c, Error_Message__c, CreatedDate ' +
+               'FROM util_closer_Case_Log__c WHERE ' + whereClause +
+               ' ORDER BY CreatedDate DESC';
     }
     
     /**
@@ -498,14 +473,4 @@ public with sharing class util_closer_LogViewerController {
         return Datetime.newInstance(d, Time.newInstance(0, 0, 0, 0)).formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
     }
     
-    private static String escapeCsvValue(String value) {
-        if (String.isBlank(value)) {
-            return '';
-        }
-        // Escape quotes and wrap in quotes if contains comma, quote, or newline
-        if (value.contains(',') || value.contains('"') || value.contains('\n')) {
-            return '"' + value.replace('"', '""') + '"';
-        }
-        return value;
-    }
 }

--- a/force-app/main/default/classes/util_closer_LogViewerController_Test.cls
+++ b/force-app/main/default/classes/util_closer_LogViewerController_Test.cls
@@ -410,20 +410,22 @@ private class util_closer_LogViewerController_Test {
     }
     
     @isTest
-    static void testExportCaseLogsAsCsv() {
+    static void testGetCaseLogExportQuery() {
         util_closer_Batch_Log__c batchLog = [SELECT Id FROM util_closer_Batch_Log__c WHERE Status__c = 'Completed' AND Execution_Mode__c = 'Simulation' LIMIT 1];
         
         Test.startTest();
-        String csv = util_closer_LogViewerController.exportCaseLogsAsCsv(batchLog.Id, null);
+        String soql = util_closer_LogViewerController.getCaseLogExportQuery(batchLog.Id, null);
         Test.stopTest();
         
-        System.assert(String.isNotBlank(csv), 'CSV should not be blank');
-        System.assert(csv.contains('Log Name'), 'CSV should contain header');
-        System.assert(csv.contains('CLOG-'), 'CSV should contain case log names');
+        System.assert(String.isNotBlank(soql), 'SOQL should not be blank');
+        System.assert(soql.startsWith('SELECT'), 'SOQL should start with SELECT');
+        System.assert(soql.contains('FROM util_closer_Case_Log__c'), 'SOQL should query Case Log object');
+        System.assert(soql.contains(String.valueOf(batchLog.Id)), 'SOQL should contain batch log ID');
+        System.assert(soql.contains('ORDER BY CreatedDate DESC'), 'SOQL should have ORDER BY clause');
     }
     
     @isTest
-    static void testExportCaseLogsAsCsv_WithFilter() {
+    static void testGetCaseLogExportQuery_WithFilter() {
         util_closer_Batch_Log__c batchLog = [SELECT Id FROM util_closer_Batch_Log__c WHERE Status__c = 'Completed' AND Execution_Mode__c = 'Simulation' LIMIT 1];
         
         util_closer_LogViewerController.CaseLogFilter filter = new util_closer_LogViewerController.CaseLogFilter();
@@ -431,13 +433,13 @@ private class util_closer_LogViewerController_Test {
         String filterJson = JSON.serialize(filter);
         
         Test.startTest();
-        String csv = util_closer_LogViewerController.exportCaseLogsAsCsv(batchLog.Id, filterJson);
+        String soql = util_closer_LogViewerController.getCaseLogExportQuery(batchLog.Id, filterJson);
         Test.stopTest();
         
-        System.assert(String.isNotBlank(csv), 'CSV should not be blank');
-        // Count rows (including header)
-        List<String> rows = csv.split('\n');
-        System.assert(rows.size() > 1, 'CSV should have data rows');
+        System.assert(String.isNotBlank(soql), 'SOQL should not be blank');
+        System.assert(soql.contains('Processing_Result__c'), 'SOQL should contain Processing_Result__c in SELECT');
+        System.assert(soql.contains('Matched'), 'SOQL should contain the filter value in WHERE clause');
+        System.assert(soql.contains(String.valueOf(batchLog.Id)), 'SOQL should contain batch log ID');
     }
     
     @isTest

--- a/force-app/main/default/classes/util_closer_RuleViewerController.cls
+++ b/force-app/main/default/classes/util_closer_RuleViewerController.cls
@@ -1,0 +1,66 @@
+/**
+ * @description Apex controller for the Rule Viewer LWC.
+ * Provides read-only access to active Case Status Auto-Closer rules.
+ */
+public with sharing class util_closer_RuleViewerController {
+
+    @TestVisible
+    private static Boolean throwExceptionOnGetRules = false;
+
+    /**
+     * @description Returns all active rules as a list of maps with camelCase keys.
+     * Wraps util_closer_RuleEngine.getActiveRules() and serializes into a
+     * flat structure that avoids custom metadata serialization issues.
+     * @return List of maps representing each active rule.
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<Map<String, Object>> getActiveRules() {
+        try {
+            if (throwExceptionOnGetRules) {
+                throw new CalloutException('Test exception for getActiveRules');
+            }
+
+            List<util_closer_Case_Status_Rule__mdt> rules = util_closer_RuleEngine.getActiveRules();
+            List<Map<String, Object>> result = new List<Map<String, Object>>();
+
+            for (util_closer_Case_Status_Rule__mdt rule : rules) {
+                Map<String, Object> m = new Map<String, Object>();
+                // Core
+                m.put('developerName', rule.DeveloperName);
+                m.put('label', rule.MasterLabel);
+                m.put('executionOrder', rule.Execution_Order__c);
+                m.put('sourceStatus', rule.Source_Status__c);
+                m.put('targetStatus', rule.Target_Status__c);
+                m.put('targetReason', rule.Target_Reason__c);
+                m.put('description', rule.Description__c);
+                m.put('stopProcessing', rule.Stop_Processing__c);
+                // Timing
+                m.put('daysSinceLastModified', rule.Days_Since_Last_Modified__c);
+                m.put('daysSinceCreated', rule.Days_Since_Created__c);
+                m.put('daysSinceLastActivity', rule.Days_Since_Last_Activity__c);
+                // Filtering
+                m.put('recordTypeDeveloperNames', rule.Record_Type_Developer_Names__c);
+                m.put('excludeRecordTypeDeveloperNames', rule.Exclude_Record_Type_Developer_Names__c);
+                m.put('origins', rule.Origins__c);
+                m.put('ownerNameLike', rule.Owner_Name_Like__c);
+                m.put('lastModifiedByNameLike', rule.Last_Modified_By_Name_Like__c);
+                m.put('additionalFilterLogic', rule.Additional_Filter_Logic__c);
+                // Child Object
+                m.put('childObjectApiName', rule.Child_Object_API_Name__c);
+                m.put('childLookupField', rule.Child_Lookup_Field__c);
+                m.put('childFilterField', rule.Child_Filter_Field__c);
+                m.put('childFilterValue', rule.Child_Filter_Value__c);
+                m.put('childFilterOperator', rule.Child_Filter_Operator__c);
+                m.put('requireChildRecord', rule.Require_Child_Record__c);
+                result.add(m);
+            }
+
+            return result;
+        } catch (Exception ex) {
+            String msg = 'Error loading rules: ' + ex.getMessage();
+            AuraHandledException e = new AuraHandledException(msg);
+            e.setMessage(msg);
+            throw e;
+        }
+    }
+}

--- a/force-app/main/default/classes/util_closer_RuleViewerController.cls-meta.xml
+++ b/force-app/main/default/classes/util_closer_RuleViewerController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/util_closer_RuleViewerController_Test.cls
+++ b/force-app/main/default/classes/util_closer_RuleViewerController_Test.cls
@@ -1,0 +1,207 @@
+/**
+ * @description Test class for util_closer_RuleViewerController.
+ * Tests the getActiveRules Aura-enabled method with mock rule injection.
+ */
+@isTest
+private class util_closer_RuleViewerController_Test {
+
+    /**
+     * @description Helper to create a mock rule with all fields populated.
+     */
+    private static util_closer_Case_Status_Rule__mdt createFullMockRule(
+        String developerName,
+        Integer executionOrder
+    ) {
+        return new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = developerName,
+            MasterLabel = developerName.replace('_', ' '),
+            Is_Active__c = true,
+            Execution_Order__c = executionOrder,
+            Source_Status__c = 'New',
+            Target_Status__c = 'Closed',
+            Target_Reason__c = 'Auto-closed',
+            Description__c = 'Test rule description',
+            Stop_Processing__c = false,
+            Days_Since_Last_Modified__c = 30,
+            Days_Since_Created__c = 60,
+            Days_Since_Last_Activity__c = 14,
+            Record_Type_Developer_Names__c = 'Support',
+            Exclude_Record_Type_Developer_Names__c = 'Internal',
+            Origins__c = 'Web;Email',
+            Owner_Name_Like__c = '%Support%',
+            Last_Modified_By_Name_Like__c = '%Auto%',
+            Additional_Filter_Logic__c = 'Status != Escalated',
+            Child_Object_API_Name__c = 'UJET__UJET_Session__c',
+            Child_Lookup_Field__c = 'Case__c',
+            Child_Filter_Field__c = 'UJET__Status__c',
+            Child_Filter_Value__c = 'Finished',
+            Child_Filter_Operator__c = 'Equals',
+            Require_Child_Record__c = true
+        );
+    }
+
+    /**
+     * @description Helper to create a minimal mock rule with only required fields.
+     */
+    private static util_closer_Case_Status_Rule__mdt createMinimalMockRule(
+        String developerName,
+        Integer executionOrder
+    ) {
+        return new util_closer_Case_Status_Rule__mdt(
+            DeveloperName = developerName,
+            MasterLabel = developerName,
+            Is_Active__c = true,
+            Execution_Order__c = executionOrder,
+            Source_Status__c = 'Open',
+            Target_Status__c = 'Closed'
+        );
+    }
+
+    @isTest
+    static void testGetActiveRules_ReturnsMappedData() {
+        // Setup
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{
+            createFullMockRule('Stale_Cases', 1),
+            createFullMockRule('Abandoned_Calls', 2)
+        };
+
+        // Execute
+        Test.startTest();
+        List<Map<String, Object>> result = util_closer_RuleViewerController.getActiveRules();
+        Test.stopTest();
+
+        // Verify
+        System.assertEquals(2, result.size(), 'Should return 2 rules');
+
+        Map<String, Object> first = result[0];
+        System.assertEquals('Stale_Cases', first.get('developerName'), 'Developer name should match');
+        System.assertEquals('Stale Cases', first.get('label'), 'Label should match');
+        System.assertEquals(1, (Decimal) first.get('executionOrder'), 'Execution order should match');
+        System.assertEquals('New', first.get('sourceStatus'), 'Source status should match');
+        System.assertEquals('Closed', first.get('targetStatus'), 'Target status should match');
+        System.assertEquals('Auto-closed', first.get('targetReason'), 'Target reason should match');
+
+        // Cleanup
+        util_closer_RuleEngine.mockRules = null;
+    }
+
+    @isTest
+    static void testGetActiveRules_EmptyRules() {
+        // Setup
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>();
+
+        // Execute
+        Test.startTest();
+        List<Map<String, Object>> result = util_closer_RuleViewerController.getActiveRules();
+        Test.stopTest();
+
+        // Verify
+        System.assertNotEquals(null, result, 'Result should not be null');
+        System.assertEquals(0, result.size(), 'Should return empty list');
+
+        // Cleanup
+        util_closer_RuleEngine.mockRules = null;
+    }
+
+    @isTest
+    static void testGetActiveRules_ForcedException() {
+        // Setup
+        util_closer_RuleViewerController.throwExceptionOnGetRules = true;
+
+        // Execute
+        Test.startTest();
+        Boolean exceptionThrown = false;
+        String exceptionMessage = '';
+        try {
+            util_closer_RuleViewerController.getActiveRules();
+        } catch (AuraHandledException ex) {
+            exceptionThrown = true;
+            exceptionMessage = ex.getMessage();
+        }
+        Test.stopTest();
+
+        // Reset
+        util_closer_RuleViewerController.throwExceptionOnGetRules = false;
+
+        // Verify
+        System.assertEquals(true, exceptionThrown, 'Should throw AuraHandledException');
+        System.assert(exceptionMessage.containsIgnoreCase('Error loading rules'),
+            'Should have proper error message. Got: ' + exceptionMessage);
+    }
+
+    @isTest
+    static void testGetActiveRules_NullFields() {
+        // Setup -- minimal rule with most fields null
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{
+            createMinimalMockRule('Minimal_Rule', 1)
+        };
+
+        // Execute
+        Test.startTest();
+        List<Map<String, Object>> result = util_closer_RuleViewerController.getActiveRules();
+        Test.stopTest();
+
+        // Verify -- should not throw, null fields map to null values
+        System.assertEquals(1, result.size(), 'Should return 1 rule');
+        Map<String, Object> rule = result[0];
+        System.assertEquals('Minimal_Rule', rule.get('developerName'), 'Developer name should match');
+        System.assertEquals(null, rule.get('targetReason'), 'Null field should map to null');
+        System.assertEquals(null, rule.get('description'), 'Null field should map to null');
+        System.assertEquals(null, rule.get('daysSinceLastModified'), 'Null field should map to null');
+        System.assertEquals(null, rule.get('childObjectApiName'), 'Null field should map to null');
+
+        // Cleanup
+        util_closer_RuleEngine.mockRules = null;
+    }
+
+    @isTest
+    static void testGetActiveRules_VerifyAllFieldMapping() {
+        // Setup -- full rule with every field populated
+        util_closer_RuleEngine.mockRules = new List<util_closer_Case_Status_Rule__mdt>{
+            createFullMockRule('Full_Rule', 5)
+        };
+
+        // Execute
+        Test.startTest();
+        List<Map<String, Object>> result = util_closer_RuleViewerController.getActiveRules();
+        Test.stopTest();
+
+        // Verify every mapped field
+        System.assertEquals(1, result.size(), 'Should return 1 rule');
+        Map<String, Object> r = result[0];
+
+        // Core
+        System.assertEquals('Full_Rule', r.get('developerName'));
+        System.assertEquals('Full Rule', r.get('label'));
+        System.assertEquals(5, (Decimal) r.get('executionOrder'));
+        System.assertEquals('New', r.get('sourceStatus'));
+        System.assertEquals('Closed', r.get('targetStatus'));
+        System.assertEquals('Auto-closed', r.get('targetReason'));
+        System.assertEquals('Test rule description', r.get('description'));
+        System.assertEquals(false, r.get('stopProcessing'));
+
+        // Timing
+        System.assertEquals(30, (Decimal) r.get('daysSinceLastModified'));
+        System.assertEquals(60, (Decimal) r.get('daysSinceCreated'));
+        System.assertEquals(14, (Decimal) r.get('daysSinceLastActivity'));
+
+        // Filtering
+        System.assertEquals('Support', r.get('recordTypeDeveloperNames'));
+        System.assertEquals('Internal', r.get('excludeRecordTypeDeveloperNames'));
+        System.assertEquals('Web;Email', r.get('origins'));
+        System.assertEquals('%Support%', r.get('ownerNameLike'));
+        System.assertEquals('%Auto%', r.get('lastModifiedByNameLike'));
+        System.assertEquals('Status != Escalated', r.get('additionalFilterLogic'));
+
+        // Child Object
+        System.assertEquals('UJET__UJET_Session__c', r.get('childObjectApiName'));
+        System.assertEquals('Case__c', r.get('childLookupField'));
+        System.assertEquals('UJET__Status__c', r.get('childFilterField'));
+        System.assertEquals('Finished', r.get('childFilterValue'));
+        System.assertEquals('Equals', r.get('childFilterOperator'));
+        System.assertEquals(true, r.get('requireChildRecord'));
+
+        // Cleanup
+        util_closer_RuleEngine.mockRules = null;
+    }
+}

--- a/force-app/main/default/classes/util_closer_RuleViewerController_Test.cls-meta.xml
+++ b/force-app/main/default/classes/util_closer_RuleViewerController_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/customMetadata/util_closer_Case_Status_Rule__mdt.Abandoned_Calls.md-meta.xml
+++ b/force-app/main/default/customMetadata/util_closer_Case_Status_Rule__mdt.Abandoned_Calls.md-meta.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Abandoned Calls</label>
+    <protected>false</protected>
+    <values>
+        <field>Is_Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Execution_Order__c</field>
+        <value xsi:type="xsd:double">5.0</value>
+    </values>
+    <values>
+        <field>Source_Status__c</field>
+        <value xsi:type="xsd:string">New</value>
+    </values>
+    <values>
+        <field>Target_Status__c</field>
+        <value xsi:type="xsd:string">Closed</value>
+    </values>
+    <values>
+        <field>Target_Reason__c</field>
+        <value xsi:type="xsd:string">Call Abandoned</value>
+    </values>
+    <values>
+        <field>Days_Since_Last_Modified__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Days_Since_Created__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Days_Since_Last_Activity__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Record_Type_Developer_Names__c</field>
+        <value xsi:type="xsd:string">PVL</value>
+    </values>
+    <values>
+        <field>Exclude_Record_Type_Developer_Names__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Additional_Filter_Logic__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">These are cases created from calls that were abandoned by the caller.</value>
+    </values>
+    <values>
+        <field>Stop_Processing__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Child_Object_API_Name__c</field>
+        <value xsi:type="xsd:string">UJET__UJET_Session__c</value>
+    </values>
+    <values>
+        <field>Child_Lookup_Field__c</field>
+        <value xsi:type="xsd:string">UJET__Case__c</value>
+    </values>
+    <values>
+        <field>Child_Filter_Field__c</field>
+        <value xsi:type="xsd:string">UJET__Fail_Reason__c</value>
+    </values>
+    <values>
+        <field>Child_Filter_Value__c</field>
+        <value xsi:type="xsd:string">eu_abandoned</value>
+    </values>
+    <values>
+        <field>Child_Filter_Operator__c</field>
+        <value xsi:type="xsd:string">Equals</value>
+    </values>
+    <values>
+        <field>Require_Child_Record__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Origins__c</field>
+        <value xsi:type="xsd:string">IVR call</value>
+    </values>
+    <values>
+        <field>Owner_Name_Like__c</field>
+        <value xsi:type="xsd:string">%Google%</value>
+    </values>
+    <values>
+        <field>Last_Modified_By_Name_Like__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/flexipages/util_closer_Dashboard.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/util_closer_Dashboard.flexipage-meta.xml
@@ -10,6 +10,12 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentName>c:util_closer_RuleViewer</componentName>
+                <identifier>ruleViewer</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>c:util_closer_LogViewer</componentName>
                 <identifier>logViewer</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.html
+++ b/force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.html
@@ -175,10 +175,10 @@
                                     </div>
                                     <div class="slds-shrink-none">
                                         <lightning-button-icon
-                                            icon-name="utility:download"
-                                            alternative-text="Export CSV"
-                                            title="Export to CSV"
-                                            onclick={handleExportCsv}
+                                            icon-name="utility:copy_to_clipboard"
+                                            alternative-text="Copy SOQL to Clipboard"
+                                            title="Copy SOQL to Clipboard"
+                                            onclick={handleCopySoql}
                                             class="slds-m-right_x-small">
                                         </lightning-button-icon>
                                         <lightning-button-icon

--- a/force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.js
+++ b/force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.js
@@ -4,7 +4,7 @@ import { NavigationMixin } from 'lightning/navigation';
 import getBatchLogs from '@salesforce/apex/util_closer_LogViewerController.getBatchLogs';
 import getCaseLogs from '@salesforce/apex/util_closer_LogViewerController.getCaseLogs';
 import getCaseLogFilterOptions from '@salesforce/apex/util_closer_LogViewerController.getCaseLogFilterOptions';
-import exportCaseLogsAsCsv from '@salesforce/apex/util_closer_LogViewerController.exportCaseLogsAsCsv';
+import getCaseLogExportQuery from '@salesforce/apex/util_closer_LogViewerController.getCaseLogExportQuery';
 
 const BATCH_PAGE_SIZE = 25;
 const CASE_PAGE_SIZE = 100;
@@ -627,8 +627,8 @@ export default class Util_closer_LogViewer extends NavigationMixin(LightningElem
         }
     }
 
-    // Export handler
-    async handleExportCsv() {
+    // Copy SOQL query to clipboard
+    async handleCopySoql() {
         try {
             const filter = {
                 processingResult: this.caseResultFilter || null,
@@ -636,23 +636,16 @@ export default class Util_closer_LogViewer extends NavigationMixin(LightningElem
                 searchTerm: this.caseSearchTerm || null
             };
 
-            const csvData = await exportCaseLogsAsCsv({
+            const soql = await getCaseLogExportQuery({
                 batchLogId: this.selectedBatchLogId,
                 filterJson: JSON.stringify(filter)
             });
 
-            // Download CSV
-            const blob = new Blob([csvData], { type: 'text/csv' });
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `case_logs_${this.selectedBatchName}_${new Date().toISOString().slice(0,10)}.csv`;
-            a.click();
-            window.URL.revokeObjectURL(url);
+            await navigator.clipboard.writeText(soql);
 
-            this.showToast('Success', 'CSV exported successfully', 'success');
+            this.showToast('SOQL Copied to Clipboard', soql, 'success', 'sticky');
         } catch (error) {
-            this.showError('Error exporting CSV', error);
+            this.showError('Error copying SOQL', error);
         }
     }
 
@@ -680,8 +673,8 @@ export default class Util_closer_LogViewer extends NavigationMixin(LightningElem
     }
 
     // Utility methods
-    showToast(title, message, variant) {
-        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    showToast(title, message, variant, mode) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant, mode: mode || 'dismissible' }));
     }
 
     showError(title, error) {

--- a/force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.js
+++ b/force-app/main/default/lwc/util_closer_LogViewer/util_closer_LogViewer.js
@@ -641,12 +641,23 @@ export default class Util_closer_LogViewer extends NavigationMixin(LightningElem
                 filterJson: JSON.stringify(filter)
             });
 
-            await navigator.clipboard.writeText(soql);
+            this.copyToClipboard(soql);
 
             this.showToast('SOQL Copied to Clipboard', soql, 'success', 'sticky');
         } catch (error) {
             this.showError('Error copying SOQL', error);
         }
+    }
+
+    copyToClipboard(text) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
     }
 
     // Navigation helpers

--- a/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.css
+++ b/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.css
@@ -1,0 +1,57 @@
+.summary-bar {
+    display: flex;
+    align-items: center;
+    padding: 0.25rem 0;
+}
+
+.count-badge {
+    --slds-c-badge-color-background: var(--slds-g-color-success-base-50, #2e844a);
+    --slds-c-badge-text-color: var(--slds-g-color-neutral-base-100, #ffffff);
+}
+
+.rules-container {
+    background-color: var(--slds-g-color-neutral-base-100, #ffffff);
+    border: 1px solid var(--slds-g-color-border-base-1, #e5e5e5);
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.rule-detail {
+    padding: 0.5rem 0;
+}
+
+.criteria-group {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--slds-g-color-border-base-1, #e5e5e5);
+}
+
+.criteria-group:last-child {
+    border-bottom: none;
+}
+
+.criteria-group-title {
+    font-size: 0.75rem;
+    color: var(--slds-g-color-neutral-base-30, #706e6b);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+    font-weight: 700;
+}
+
+.rule-label {
+    display: block;
+    font-weight: 600;
+    color: var(--slds-g-color-neutral-base-30, #706e6b);
+    font-size: 0.75rem;
+    margin-bottom: 0.125rem;
+}
+
+.rule-value {
+    display: block;
+    color: var(--slds-g-color-neutral-base-10, #080707);
+    font-size: 0.875rem;
+}
+
+.rule-description {
+    font-style: italic;
+}

--- a/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.html
+++ b/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.html
@@ -1,0 +1,220 @@
+<template>
+    <lightning-card title="Active Rules" icon-name="standard:dynamic_highlights_panel">
+        <div slot="actions">
+            <lightning-button-icon
+                icon-name="utility:refresh"
+                alternative-text="Refresh rules"
+                title="Refresh rules"
+                onclick={handleRefresh}
+                class="slds-m-right_x-small">
+            </lightning-button-icon>
+            <lightning-button-icon
+                icon-name={expandIcon}
+                alternative-text={expandLabel}
+                title={expandLabel}
+                onclick={handleToggleExpand}>
+            </lightning-button-icon>
+        </div>
+
+        <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+            <!-- Loading State -->
+            <template if:true={isLoading}>
+                <div class="slds-align_absolute-center" style="height: 3rem;">
+                    <lightning-spinner alternative-text="Loading" size="small"></lightning-spinner>
+                </div>
+            </template>
+
+            <!-- Error State -->
+            <template if:true={hasError}>
+                <div class="slds-box slds-box_x-small slds-theme_error slds-m-bottom_small">
+                    <strong>Error:</strong> {errorMessage}
+                </div>
+            </template>
+
+            <template if:false={isLoading}>
+                <!-- Summary Bar (always visible) -->
+                <div class="summary-bar">
+                    <span class="slds-text-body_small">
+                        <lightning-badge label={ruleCountLabel} class="count-badge"></lightning-badge>
+                    </span>
+                    <template if:true={hasNoRules}>
+                        <span class="slds-text-body_small slds-text-color_weak slds-m-left_small">
+                            No active rules configured.
+                        </span>
+                    </template>
+                </div>
+
+                <!-- Expanded: Rule Accordion -->
+                <template if:true={showRules}>
+                    <div class="rules-container slds-m-top_small">
+                        <lightning-accordion allow-multiple-sections-open>
+                            <template for:each={formattedRules} for:item="rule">
+                                <lightning-accordion-section
+                                    key={rule.developerName}
+                                    name={rule.developerName}
+                                    label={rule.sectionLabel}>
+
+                                    <div class="rule-detail">
+                                        <!-- Core Criteria -->
+                                        <div class="criteria-group">
+                                            <h4 class="criteria-group-title">Status Transition</h4>
+                                            <div class="slds-grid slds-wrap">
+                                                <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                    <span class="rule-label">Source Status</span>
+                                                    <span class="rule-value">{rule.sourceStatus}</span>
+                                                </div>
+                                                <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                    <span class="rule-label">Target Status</span>
+                                                    <span class="rule-value">{rule.targetStatus}</span>
+                                                </div>
+                                                <template if:true={rule.targetReason}>
+                                                    <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                        <span class="rule-label">Target Reason</span>
+                                                        <span class="rule-value">{rule.targetReason}</span>
+                                                    </div>
+                                                </template>
+                                                <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                    <span class="rule-label">Execution Order</span>
+                                                    <span class="rule-value">{rule.executionOrder}</span>
+                                                </div>
+                                                <template if:true={rule.stopProcessing}>
+                                                    <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                        <span class="rule-label">Stop Processing</span>
+                                                        <span class="rule-value">Yes</span>
+                                                    </div>
+                                                </template>
+                                            </div>
+                                            <template if:true={rule.description}>
+                                                <div class="slds-p-around_xx-small">
+                                                    <span class="rule-label">Description</span>
+                                                    <span class="rule-value rule-description">{rule.description}</span>
+                                                </div>
+                                            </template>
+                                        </div>
+
+                                        <!-- Timing Criteria -->
+                                        <template if:true={rule.hasTimingCriteria}>
+                                            <div class="criteria-group">
+                                                <h4 class="criteria-group-title">Timing Criteria</h4>
+                                                <div class="slds-grid slds-wrap">
+                                                    <template if:true={rule.daysSinceLastModified}>
+                                                        <div class="slds-col slds-size_1-of-3 slds-p-around_xx-small">
+                                                            <span class="rule-label">Days Since Last Modified</span>
+                                                            <span class="rule-value">{rule.daysSinceLastModified}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.daysSinceCreated}>
+                                                        <div class="slds-col slds-size_1-of-3 slds-p-around_xx-small">
+                                                            <span class="rule-label">Days Since Created</span>
+                                                            <span class="rule-value">{rule.daysSinceCreated}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.daysSinceLastActivity}>
+                                                        <div class="slds-col slds-size_1-of-3 slds-p-around_xx-small">
+                                                            <span class="rule-label">Days Since Last Activity</span>
+                                                            <span class="rule-value">{rule.daysSinceLastActivity}</span>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+
+                                        <!-- Filtering Criteria -->
+                                        <template if:true={rule.hasFilterCriteria}>
+                                            <div class="criteria-group">
+                                                <h4 class="criteria-group-title">Filtering Criteria</h4>
+                                                <div class="slds-grid slds-wrap">
+                                                    <template if:true={rule.recordTypeDeveloperNames}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Record Types (Include)</span>
+                                                            <span class="rule-value">{rule.recordTypeDeveloperNames}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.excludeRecordTypeDeveloperNames}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Record Types (Exclude)</span>
+                                                            <span class="rule-value">{rule.excludeRecordTypeDeveloperNames}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.origins}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Origins</span>
+                                                            <span class="rule-value">{rule.origins}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.ownerNameLike}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Owner Name Like</span>
+                                                            <span class="rule-value">{rule.ownerNameLike}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.lastModifiedByNameLike}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Last Modified By Name Like</span>
+                                                            <span class="rule-value">{rule.lastModifiedByNameLike}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.additionalFilterLogic}>
+                                                        <div class="slds-col slds-size_1-of-1 slds-p-around_xx-small">
+                                                            <span class="rule-label">Additional Filter Logic</span>
+                                                            <span class="rule-value">{rule.additionalFilterLogic}</span>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+
+                                        <!-- Child Object Criteria -->
+                                        <template if:true={rule.hasChildCriteria}>
+                                            <div class="criteria-group">
+                                                <h4 class="criteria-group-title">Child Object Criteria</h4>
+                                                <div class="slds-grid slds-wrap">
+                                                    <template if:true={rule.childObjectApiName}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Child Object</span>
+                                                            <span class="rule-value">{rule.childObjectApiName}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.childLookupField}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Lookup Field</span>
+                                                            <span class="rule-value">{rule.childLookupField}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.childFilterField}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Filter Field</span>
+                                                            <span class="rule-value">{rule.childFilterField}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.childFilterValue}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Filter Value</span>
+                                                            <span class="rule-value">{rule.childFilterValue}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.childFilterOperator}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Filter Operator</span>
+                                                            <span class="rule-value">{rule.childFilterOperator}</span>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={rule.requireChildRecord}>
+                                                        <div class="slds-col slds-size_1-of-2 slds-p-around_xx-small">
+                                                            <span class="rule-label">Require Child Record</span>
+                                                            <span class="rule-value">Yes</span>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </lightning-accordion-section>
+                            </template>
+                        </lightning-accordion>
+                    </div>
+                </template>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js
+++ b/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js
@@ -1,0 +1,146 @@
+import { LightningElement, track, wire } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { refreshApex } from '@salesforce/apex';
+import getActiveRules from '@salesforce/apex/util_closer_RuleViewerController.getActiveRules';
+
+export default class Util_closer_RuleViewer extends LightningElement {
+    @track isExpanded = false;
+    @track rules = [];
+    @track isLoading = true;
+    @track error;
+
+    wiredRulesResult;
+
+    @wire(getActiveRules)
+    wiredRules(result) {
+        this.wiredRulesResult = result;
+        if (result.data) {
+            this.rules = result.data;
+            this.error = undefined;
+            this.isLoading = false;
+        } else if (result.error) {
+            this.error = result.error;
+            this.rules = [];
+            this.isLoading = false;
+        }
+    }
+
+    get ruleCount() {
+        return this.rules.length;
+    }
+
+    get ruleCountLabel() {
+        return `${this.ruleCount} Active`;
+    }
+
+    get hasRules() {
+        return this.rules.length > 0;
+    }
+
+    get hasNoRules() {
+        return !this.isLoading && this.rules.length === 0;
+    }
+
+    get hasError() {
+        return this.error !== undefined && this.error !== null;
+    }
+
+    get errorMessage() {
+        if (!this.error) return '';
+        if (this.error.body && this.error.body.message) {
+            return this.error.body.message;
+        }
+        if (this.error.message) {
+            return this.error.message;
+        }
+        return 'An unknown error occurred';
+    }
+
+    get expandIcon() {
+        return this.isExpanded ? 'utility:chevrondown' : 'utility:chevronright';
+    }
+
+    get expandLabel() {
+        return this.isExpanded ? 'Collapse rules' : 'Expand rules';
+    }
+
+    get showRules() {
+        return this.isExpanded && this.hasRules;
+    }
+
+    get formattedRules() {
+        return this.rules.map(rule => {
+            const timingParts = [];
+            if (rule.daysSinceLastModified) {
+                timingParts.push(rule.daysSinceLastModified + 'd modified');
+            }
+            if (rule.daysSinceCreated) {
+                timingParts.push(rule.daysSinceCreated + 'd created');
+            }
+            if (rule.daysSinceLastActivity) {
+                timingParts.push(rule.daysSinceLastActivity + 'd activity');
+            }
+
+            const timingSummary = timingParts.length > 0
+                ? ' | ' + timingParts.join(', ')
+                : '';
+
+            return {
+                ...rule,
+                sectionLabel: '#' + rule.executionOrder + ' — ' + rule.label +
+                    ' | ' + rule.sourceStatus + ' → ' + rule.targetStatus +
+                    timingSummary,
+                hasTimingCriteria: rule.daysSinceLastModified != null ||
+                    rule.daysSinceCreated != null ||
+                    rule.daysSinceLastActivity != null,
+                hasFilterCriteria: rule.recordTypeDeveloperNames != null ||
+                    rule.excludeRecordTypeDeveloperNames != null ||
+                    rule.origins != null ||
+                    rule.ownerNameLike != null ||
+                    rule.lastModifiedByNameLike != null ||
+                    rule.additionalFilterLogic != null,
+                hasChildCriteria: rule.childObjectApiName != null ||
+                    rule.childLookupField != null ||
+                    rule.childFilterField != null ||
+                    rule.childFilterValue != null ||
+                    rule.childFilterOperator != null ||
+                    rule.requireChildRecord === true
+            };
+        });
+    }
+
+    handleToggleExpand() {
+        this.isExpanded = !this.isExpanded;
+    }
+
+    handleRefresh() {
+        this.isLoading = true;
+        refreshApex(this.wiredRulesResult)
+            .then(() => {
+                this.isLoading = false;
+                this.showToast('Success', 'Rules refreshed', 'success');
+            })
+            .catch(error => {
+                this.handleError(error);
+                this.isLoading = false;
+            });
+    }
+
+    handleError(error) {
+        let message = 'An unknown error occurred';
+        if (error.body && error.body.message) {
+            message = error.body.message;
+        } else if (error.message) {
+            message = error.message;
+        }
+        this.showToast('Error', message, 'error');
+    }
+
+    showToast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({
+            title: title,
+            message: message,
+            variant: variant
+        }));
+    }
+}

--- a/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js-meta.xml
+++ b/force-app/main/default/lwc/util_closer_RuleViewer/util_closer_RuleViewer.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Closinator Active Rules</masterLabel>
+    <description>Read-only display of active Case Status Auto-Closer rules and criteria</description>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__Tab</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Child_Filter_Field__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Child_Filter_Field__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Child_Filter_Field__c</fullName>
-    <description>API name of the field on the child object to evaluate (e.g., UJET__Status__c).</description>
+    <description>API name of the field on the child object to evaluate. Enter the field name only, without the object prefix. Correct: UJET__Fail_Reason__c. Incorrect: UJET__UJET_Session__c.UJET__Fail_Reason__c.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the API name of the field on the child object to check against the filter value.</inlineHelpText>
+    <inlineHelpText>Field API name only. Do not use dot notation. (Example: UJET__Status__c).</inlineHelpText>
     <label>Child Filter Field</label>
     <length>100</length>
     <required>false</required>

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Child_Filter_Value__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Child_Filter_Value__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Child_Filter_Value__c</fullName>
-    <description>Value(s) to match on the child filter field. Use semicolon to separate multiple values (e.g., Finished;Completed).</description>
+    <description>Raw value(s) to match on the child filter field. Do not wrap in quotes. Use semicolons to separate multiple values. Example: eu_abandoned or Finished;Completed.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter value(s) to match. Separate multiple values with semicolons.</inlineHelpText>
+    <inlineHelpText>Raw values only. Do not wrap in quotes. Separate multiple values with semicolons. (Example: Finished;Completed).</inlineHelpText>
     <label>Child Filter Value</label>
     <length>255</length>
     <required>false</required>

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Last_Modified_By_Name_Like__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Last_Modified_By_Name_Like__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Last_Modified_By_Name_Like__c</fullName>
-    <description>Pattern to match against Last Modified By Name using LIKE operator. Supports % as wildcard. Example: %Google% matches names containing Google.</description>
+    <description>Optional LIKE pattern to restrict this rule by Last Modified By Name. Leave blank to apply to all. Use % as multi-character wildcard and _ as single-character wildcard.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter a pattern to match the Last Modified By Name. Use % as wildcard. Example: %Google% matches any name containing Google.</inlineHelpText>
+    <inlineHelpText>Leave blank to match all. Use % as wildcard. (Example: %Google%).</inlineHelpText>
     <label>Last Modified By Name Like</label>
     <length>255</length>
     <required>false</required>

--- a/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Owner_Name_Like__c.field-meta.xml
+++ b/force-app/main/default/objects/util_closer_Case_Status_Rule__mdt/fields/Owner_Name_Like__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Owner_Name_Like__c</fullName>
-    <description>Pattern to match against Owner Name using LIKE operator. Supports % as wildcard. Example: Google% matches names starting with Google.</description>
+    <description>Optional LIKE pattern to restrict this rule by Case Owner Name. Leave blank to apply to all owners. Use % as multi-character wildcard and _ as single-character wildcard.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter a pattern to match the Case Owner Name. Use % as wildcard. Example: %Google% matches any owner name containing Google.</inlineHelpText>
+    <inlineHelpText>Leave blank to match all owners. Use % as wildcard. (Example: %Google%).</inlineHelpText>
     <label>Owner Name Like</label>
     <length>255</length>
     <required>false</required>


### PR DESCRIPTION
## Summary

- Replace the CSV download button in the Log Viewer with a "Copy SOQL to Clipboard" button that copies the equivalent SOQL query and displays it in a sticky toast
- The previous CSV export exceeded the 6 MB Apex heap size limit for batch runs with more than ~6,000 case logs, causing errors for users
- Uses `document.execCommand('copy')` fallback since `navigator.clipboard` is unavailable in Lightning Locker Service

## Changes

| File | Change |
|------|--------|
| `util_closer_LogViewerController.cls` | Replaced `exportCaseLogsAsCsv` with `getCaseLogExportQuery` -- returns SOQL string without executing it |
| `util_closer_LogViewerController_Test.cls` | Updated tests to validate the returned SOQL string |
| `util_closer_LogViewer.js` | Replaced Blob/download handler with clipboard copy + sticky toast; added Locker Service-compatible clipboard fallback |
| `util_closer_LogViewer.html` | Changed button icon to `utility:copy_to_clipboard`, updated tooltip |
| `docs/closinator-soql-toast/soql-toast-feature.md` | Feature documentation |

## Test plan

- [ ] Open Closinator tab > Log Viewer > select a batch to open Case Logs panel
- [ ] Click the clipboard icon button in the Case Logs panel header
- [ ] Verify a sticky success toast appears showing the full SOQL query
- [ ] Verify the SOQL is in the clipboard (paste into Dev Console or text editor)
- [ ] Apply filters (result, rule, search) and click the button again -- verify the SOQL WHERE clause includes the filter conditions
- [ ] Dismiss the toast with the X button


Made with [Cursor](https://cursor.com)